### PR TITLE
Change regex to ignore custom descriptions

### DIFF
--- a/src/parseEconItem/ParsedEcon/getDescriptions/paint.js
+++ b/src/parseEconItem/ParsedEcon/getDescriptions/paint.js
@@ -4,7 +4,7 @@
  * @return {boolean}
  */
 exports.isPaint = function (description) {
-	return /Paint Color: /.test(description.value);
+	return /^Paint Color: /.test(description.value);
 };
 
 /**

--- a/src/parseEconItem/ParsedEcon/getDescriptions/spell.js
+++ b/src/parseEconItem/ParsedEcon/getDescriptions/spell.js
@@ -4,7 +4,7 @@
  * @return {boolean}
  */
 exports.isSpell = function (description) {
-	return /Halloween: .*/.test(description.value);
+	return /^Halloween: .*/.test(description.value);
 };
 
 /**


### PR DESCRIPTION
Check at start of string, since custom descriptions start with '' 