### PR TITLE
Massively improve performance of getDefindex()

### DIFF
--- a/src/static/schema.ts
+++ b/src/static/schema.ts
@@ -200,6 +200,7 @@ export class Schema implements ISchema {
 		let min = 0;
 		let max = this.itemLookupTableItems.length - 1;
 		let linearStartIndex: number = -1;
+		let linearEndIndex: number = -1;
 
 		while (min <= max) {
 			const mid = Math.floor((min + max) / 2);
@@ -212,6 +213,8 @@ export class Schema implements ISchema {
 			} else {
 				//found item
 				linearStartIndex = this.itemLookupTableIndexes[mid];
+				linearEndIndex =
+					this.itemLookupTableIndexes[mid + 1] || this.items.length;
 				break;
 			}
 		}
@@ -219,18 +222,13 @@ export class Schema implements ISchema {
 		if (linearStartIndex === -1) return null;
 
 		//linear search for item
-		for (let i = linearStartIndex; i < this.items.length; i++) {
+		for (let i = linearStartIndex; i < linearEndIndex; i++) {
 			const item: SchemaItem = this.items[i];
 			const name: string = selectName(item);
-			if (name === search) {
-				if (!hasUpgradeable(item) || isUpgradeable(item.name)) {
-					return item.defindex;
-				}
-				upgradeableDfx = item.defindex;
-			} else {
-				//stop searching if we've reached the next item
-				break;
+			if (!hasUpgradeable(item) || isUpgradeable(item.name)) {
+				return item.defindex;
 			}
+			upgradeableDfx = item.defindex;
 		}
 
 		return upgradeableDfx;


### PR DESCRIPTION
### Summary
This PR reduces the time complexity of ISchema.getDefindex() from O(n) to O(log(n)) by implementing Binary Search (rather than the linear search that was used before). This solves some performance issues with many of `tf2-item-format`'s functions, which was caused the slow speed of this search. This new implementation also has a preference for lower defindexes (provided items have the same `item_name`) just like the original implementation.

### Notes
- This implementation adds a costly one-time precompute step. It may be advisable to run this step upon module load, rather than when it is first needed.

### New Algorithm

#### Precompute Step
1. Sort `this.items` by `item.item_name`, falling back to `item.defindex` as needed.
2. Fill `itemLookupTableItems` with `item_name`s, in the order in which they appear in `this.items`
3. Fill `itemLookupTableIndexes` with the first index in `this.items` where the corresponding `item_name` in `itemLookupTableItems` first appears.

#### getDefindex()
1. Perform a binary search over `itemLookupTableItems`
2. Find the corresponding index entry from `itemLookupTableIndexes`
3. Starting at the index, perform a linear search over all items with the same `item_name`

