### PR TITLE
fix: keyless war paint cases

### DIFF
--- a/src/static/schema.ts
+++ b/src/static/schema.ts
@@ -35,6 +35,13 @@ const DEFINDEXES: { [name: string]: number } = {
 	'Limited Late Summer Crate Key': 5762,
 	'Naughty Winter Crate Key 2014': 5791,
 	'Nice Winter Crate Key 2014': 5792,
+
+	"'Decorated War Hero' War Paint Civilian Grade Keyless Case": 18000,
+	"'Decorated War Hero' War Paint Freelance Grade Keyless Case": 18001,
+	"'Decorated War Hero' War Paint Mercenary Grade Keyless Case": 18002,
+	"'Contract Campaigner' War Paint Civilian Grade Keyless Case": 18003,
+	"'Contract Campaigner' War Paint Freelance Grade Keyless Case": 18004,
+	"'Contract Campaigner' War Paint Mercenary Grade Keyless Case": 18005,
 };
 
 const NAMES: { [defindex: number]: string } = {
@@ -57,6 +64,12 @@ const NAMES: { [defindex: number]: string } = {
 	5792: 'Nice Winter Crate Key 2014',
 	20000: 'Strangifier Chemistry Set',
 	20005: 'Chemistry Set',
+	18000: "'Decorated War Hero' War Paint Civilian Grade Keyless Case",
+	18001: "'Decorated War Hero' War Paint Freelance Grade Keyless Case",
+	18002: "'Decorated War Hero' War Paint Mercenary Grade Keyless Case",
+	18003: "'Contract Campaigner' War Paint Civilian Grade Keyless Case",
+	18004: "'Contract Campaigner' War Paint Freelance Grade Keyless Case",
+	18005: "'Contract Campaigner' War Paint Mercenary Grade Keyless Case",
 };
 
 /* TODO: Set boundaries between these.
@@ -265,7 +278,7 @@ export class Schema implements ISchema {
 		if (!this.itemsGame) this.loadItemsGame();
 
 		if (!isNumber(defindexOrName)) {
-			const defindex = this.getDefindex(defindexOrName);;
+			const defindex = this.getDefindex(defindexOrName);
 			if (!defindex) return 0;
 			defindexOrName = defindex;
 		}
@@ -274,7 +287,8 @@ export class Schema implements ISchema {
 		if (!item) return 0;
 
 		const crateSeries = parseInt(
-			(item.static_attrs && item.static_attrs['set supply crate series']) as string
+			(item.static_attrs &&
+				item.static_attrs['set supply crate series']) as string
 		);
 
 		return isNaN(crateSeries) ? 0 : crateSeries;

--- a/test/parseString.js
+++ b/test/parseString.js
@@ -1,6 +1,6 @@
 const { assert } = require('chai');
 
-const { parseString, schema, Schema } = require('../dist/static');
+const { parseString, Schema } = require('../dist/static');
 const { createFormat } = require('../dist');
 
 describe('parseString', () => {
@@ -608,6 +608,21 @@ describe('parseString', () => {
 			craftable: true,
 			quality: 'Unusual',
 			effect: 'Festivized Formation'
+		});
+	});
+
+	it("Case #49 -'Contract Campaigner' War Paint Freelance Grade Keyless Case #115", () => {
+		const itemObject = parseString(
+			"'Contract Campaigner' War Paint Freelance Grade Keyless Case #115",
+			false,
+			false,
+		);
+		
+		assert.deepEqual(itemObject, {
+			name: "'Contract Campaigner' War Paint Freelance Grade Keyless Case",
+			craftable: true,
+			quality: 'Unique',
+			itemNumber: { type: 'crate', value: 115 },
 		});
 	});
 });
@@ -1277,6 +1292,21 @@ describe('parseString with numbers', () => {
 			craftable: true,
 			quality: 5,
 			effect: 3108
+		});
+	});
+
+		it("Case #49 -'Contract Campaigner' War Paint Freelance Grade Keyless Case #115", () => {
+		const itemObject = parseString(
+			"'Contract Campaigner' War Paint Freelance Grade Keyless Case #115",
+			true,
+			false,
+		);
+		
+		assert.deepEqual(itemObject, {
+			name: "'Contract Campaigner' War Paint Freelance Grade Keyless Case",
+			craftable: true,
+			quality: 6,
+			itemNumber: { type: 'crate', value: 115 },
 		});
 	});
 });
@@ -2093,7 +2123,7 @@ describe('parseString with defindexes and numbers.', () => {
 		});
 	});
 
-	it('Case #46 - Haunted Kraken Rotation Sensation', () => {
+	it('Case #56 - Haunted Kraken Rotation Sensation', () => {
 		const itemObject = parseString('Haunted Kraken Rotation Sensation', true, true);
 
 		assert.deepEqual(itemObject, {
@@ -2105,7 +2135,7 @@ describe('parseString with defindexes and numbers.', () => {
 		});
 	});
 
-	it('Case #47 - Strange Health and Hell (Green) War Paint', () => {
+	it('Case #57 - Strange Health and Hell (Green) War Paint', () => {
 		const itemObject = parseString('Strange Health and Hell (Green) War Paint', true, true);
 
 		assert.deepEqual(itemObject, {
@@ -2117,7 +2147,7 @@ describe('parseString with defindexes and numbers.', () => {
 		});
 	});
 
-	it('Case #48 - Health and Hell (Green) Rocket Launcher', () => {
+	it('Case #58 - Health and Hell (Green) Rocket Launcher', () => {
 		const itemObject = parseString('Health and Hell (Green) Rocket Launcher', true, true);
 
 		assert.deepEqual(itemObject, {
@@ -2129,7 +2159,7 @@ describe('parseString with defindexes and numbers.', () => {
 		});
 	});
 
-	it('Case #49 - Health and Hell Iron Bomber', () => {
+	it('Case #59 - Health and Hell Iron Bomber', () => {
 		const itemObject = parseString('Health and Hell Iron Bomber', true, true);
 
 		assert.deepEqual(itemObject, {
@@ -2141,7 +2171,7 @@ describe('parseString with defindexes and numbers.', () => {
 		});
 	});
 
-	it('Case #50 - Frostbite Bonnet ', () => {
+	it('Case #60 - Frostbite Bonnet ', () => {
 		const itemObject = parseString('Frostbite Bonnet', true, true);
 
 		assert.deepEqual(itemObject, {
@@ -2152,7 +2182,7 @@ describe('parseString with defindexes and numbers.', () => {
 		});
 	});
 
-	it('Case #51 - Frostbite Bonnet ', () => {
+	it('Case #61 - Frostbite Bonnet ', () => {
 		const itemObject = parseString('Festivized Formation Taunt: Most Wanted', true, true);
 
 		assert.deepEqual(itemObject, {
@@ -2161,6 +2191,22 @@ describe('parseString with defindexes and numbers.', () => {
 			quality: 5,
 			defindex: 30614,
 			effect: 3108
+		});
+	});
+
+	it("Case #62 -'Contract Campaigner' War Paint Freelance Grade Keyless Case #115", () => {
+		const itemObject = parseString(
+			"'Contract Campaigner' War Paint Freelance Grade Keyless Case #115",
+			true,
+			true,
+		);
+		
+		assert.deepEqual(itemObject, {
+			name: "'Contract Campaigner' War Paint Freelance Grade Keyless Case",
+			craftable: true,
+			quality: 6,	
+			defindex: 18004,
+			itemNumber: { type: 'crate', value: 115 },
 		});
 	});
 });

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -1,6 +1,6 @@
 const { assert } = require('chai');
 
-const { stringify, parseString } = require('../dist/static');
+const { stringify } = require('../dist/static');
 
 describe('stringify', () => {
 	it('Case #1', () => {
@@ -11,10 +11,13 @@ describe('stringify', () => {
 			wear: 'Battle Scarred',
 			texture: 'Aqua Marine',
 			effect: 'Cool',
-			quality: 'Unusual'
+			quality: 'Unusual',
 		});
 
-		assert.equal(itemString, 'Cool Killstreak Aqua Marine Rocket Launcher (Battle Scarred)');
+		assert.equal(
+			itemString,
+			'Cool Killstreak Aqua Marine Rocket Launcher (Battle Scarred)'
+		);
 	});
 
 	it('Case #2', () => {
@@ -22,23 +25,29 @@ describe('stringify', () => {
 			name: 'Rocket Launcher',
 			craftable: true,
 			wear: 'Factory New',
-			texture: 'High Roller\'s',
-			quality: 'Strange'
+			texture: "High Roller's",
+			quality: 'Strange',
 		});
 
-		assert.equal(itemString, 'Strange High Roller\'s Rocket Launcher (Factory New)');
+		assert.equal(
+			itemString,
+			"Strange High Roller's Rocket Launcher (Factory New)"
+		);
 	});
 
 	it('Case #3', () => {
 		const itemString = stringify({
 			name: 'Chemistry Set',
 			craftable: true,
-			output: 'Battalion\'s Backup',
-			outputQuality: 'Collector\'s',
-			quality: 'Unique'
+			output: "Battalion's Backup",
+			outputQuality: "Collector's",
+			quality: 'Unique',
 		});
 
-		assert.equal(itemString, 'Collector\'s Battalion\'s Backup Chemistry Set');
+		assert.equal(
+			itemString,
+			"Collector's Battalion's Backup Chemistry Set"
+		);
 	});
 
 	it('Case #4', () => {
@@ -48,10 +57,13 @@ describe('stringify', () => {
 			australium: true,
 			festivized: true,
 			killstreak: 'Professional Killstreak',
-			quality: 'Strange'
+			quality: 'Strange',
 		});
 
-		assert.equal(itemString, 'Strange Festivized Professional Killstreak Australium Scattergun');
+		assert.equal(
+			itemString,
+			'Strange Festivized Professional Killstreak Australium Scattergun'
+		);
 	});
 
 	it('Case #5', () => {
@@ -59,7 +71,7 @@ describe('stringify', () => {
 			name: 'Modest Pile of Hat',
 			craftable: true,
 			effect: 'Demonflame',
-			quality: 'Unusual'
+			quality: 'Unusual',
 		});
 
 		assert.equal(itemString, 'Demonflame Modest Pile of Hat');
@@ -71,7 +83,7 @@ describe('stringify', () => {
 			craftable: true,
 			effect: 'Omniscient Orb',
 			quality: 'Unusual',
-			elevated: true
+			elevated: true,
 		});
 
 		assert.equal(itemString, 'Strange Omniscient Orb Balloonihoodie');
@@ -83,10 +95,13 @@ describe('stringify', () => {
 			craftable: false,
 			killstreak: 'Specialized Killstreak',
 			target: 'Gunboats',
-			quality: 'Unique'
+			quality: 'Unique',
 		});
 
-		assert.equal(itemString, 'Non-Craftable Specialized Killstreak Gunboats Kit Fabricator');
+		assert.equal(
+			itemString,
+			'Non-Craftable Specialized Killstreak Gunboats Kit Fabricator'
+		);
 	});
 
 	it('Case #8', () => {
@@ -96,7 +111,7 @@ describe('stringify', () => {
 			target: 'Archimedes',
 			output: 'Strangifier',
 			outputQuality: 'Unique',
-			quality: 'Unique'
+			quality: 'Unique',
 		});
 
 		assert.equal(itemString, 'Archimedes Strangifier Chemistry Set');
@@ -106,7 +121,7 @@ describe('stringify', () => {
 		const itemString = stringify({
 			name: 'Backwards Ballcap',
 			craftable: true,
-			quality: 'Strange'
+			quality: 'Strange',
 		});
 
 		assert.equal(itemString, 'Strange Backwards Ballcap');
@@ -118,10 +133,13 @@ describe('stringify', () => {
 			craftable: true,
 			killstreak: 'Professional Killstreak',
 			target: 'Iron Curtain',
-			quality: 'Unique'
+			quality: 'Unique',
 		});
 
-		assert.equal(itemString, 'Professional Killstreak Iron Curtain Kit Fabricator');
+		assert.equal(
+			itemString,
+			'Professional Killstreak Iron Curtain Kit Fabricator'
+		);
 	});
 
 	it('Case #11', () => {
@@ -129,10 +147,13 @@ describe('stringify', () => {
 			name: 'Festive Grenade Launcher',
 			craftable: true,
 			killstreak: 'Professional Killstreak',
-			quality: 'Strange'
+			quality: 'Strange',
 		});
 
-		assert.equal(itemString, 'Strange Professional Killstreak Festive Grenade Launcher');
+		assert.equal(
+			itemString,
+			'Strange Professional Killstreak Festive Grenade Launcher'
+		);
 	});
 
 	it('Case #12', () => {
@@ -140,14 +161,18 @@ describe('stringify', () => {
 			name: 'Sniper Rifle',
 			craftable: true,
 			quality: 'Unique',
-			elevated: true
+			elevated: true,
 		});
 
 		assert.equal(itemString, 'Strange Unique Sniper Rifle');
 	});
 
 	it('Case #13', () => {
-		const itemString = stringify({ name: 'Australium Gold', craftable: true, quality: 'Unique' });
+		const itemString = stringify({
+			name: 'Australium Gold',
+			craftable: true,
+			quality: 'Unique',
+		});
 
 		assert.equal(itemString, 'Australium Gold');
 	});
@@ -157,7 +182,7 @@ describe('stringify', () => {
 			name: 'Blue Moon Case',
 			craftable: true,
 			itemNumber: { type: 'case', value: '118' },
-			quality: 'Unique'
+			quality: 'Unique',
 		});
 
 		assert.equal(itemString, 'Blue Moon Case #118');
@@ -168,17 +193,22 @@ describe('stringify', () => {
 			name: 'Hat',
 			craftable: true,
 			itemNumber: { type: 'craft', value: '25' },
-			quality: 'Unique'
+			quality: 'Unique',
 		});
 
 		assert.equal(itemString, 'Hat #25');
 	});
 
 	it('Case #16', () => {
-		const itemString = stringify({ name: 'Tartan Shade', craftable: true, quality: 'Unique', isUniqueHat: true });
+		const itemString = stringify({
+			name: 'Tartan Shade',
+			craftable: true,
+			quality: 'Unique',
+			isUniqueHat: true,
+		});
 
 		assert.deepEqual(itemString, 'The Tartan Shade');
-	})
+	});
 
 	it('Case #17', () => {
 		const itemString = stringify({
@@ -188,9 +218,12 @@ describe('stringify', () => {
 			target: 'Taunt: Kazotsky Kick',
 		});
 
-		assert.deepEqual(itemString, 'Unusual Taunt: Kazotsky Kick Unusualifier');
-	})
-})
+		assert.deepEqual(
+			itemString,
+			'Unusual Taunt: Kazotsky Kick Unusualifier'
+		);
+	});
+});
 
 describe('stringify from defindexes and numbers.', () => {
 	it('Case #1', () => {
@@ -199,10 +232,13 @@ describe('stringify from defindexes and numbers.', () => {
 			quality: 6,
 			craftable: true,
 			killstreak: 3,
-			targetDefindex: 1151
-		})
+			targetDefindex: 1151,
+		});
 
-		assert.equal(itemString, 'Professional Killstreak Iron Bomber Kit Fabricator');
+		assert.equal(
+			itemString,
+			'Professional Killstreak Iron Bomber Kit Fabricator'
+		);
 	});
 
 	it('Case #2', () => {
@@ -215,9 +251,12 @@ describe('stringify from defindexes and numbers.', () => {
 			effect: 703,
 			quality: 5,
 			defindex: 205,
-		})
+		});
 
-		assert.equal(itemString, 'Cool Killstreak Aqua Marine Rocket Launcher (Battle Scarred)');
+		assert.equal(
+			itemString,
+			'Cool Killstreak Aqua Marine Rocket Launcher (Battle Scarred)'
+		);
 	});
 
 	it('Case #3', () => {
@@ -228,9 +267,12 @@ describe('stringify from defindexes and numbers.', () => {
 			texture: 79,
 			quality: 11,
 			defindex: 205,
-		})
+		});
 
-		assert.equal(itemString, 'Strange High Roller\'s Rocket Launcher (Factory New)');
+		assert.equal(
+			itemString,
+			"Strange High Roller's Rocket Launcher (Factory New)"
+		);
 	});
 
 	it('Case #4', () => {
@@ -242,9 +284,12 @@ describe('stringify from defindexes and numbers.', () => {
 			quality: 6,
 			outputDefindex: 226,
 			defindex: 20000,
-		})
+		});
 
-		assert.equal(itemString, 'Collector\'s Battalion\'s Backup Chemistry Set');
+		assert.equal(
+			itemString,
+			"Collector's Battalion's Backup Chemistry Set"
+		);
 	});
 
 	it('Case #5', () => {
@@ -256,9 +301,12 @@ describe('stringify from defindexes and numbers.', () => {
 			killstreak: 3,
 			quality: 11,
 			defindex: 200,
-		})
+		});
 
-		assert.equal(itemString, 'Strange Festivized Professional Killstreak Australium Scattergun');
+		assert.equal(
+			itemString,
+			'Strange Festivized Professional Killstreak Australium Scattergun'
+		);
 	});
 
 	it('Case #6', () => {
@@ -268,7 +316,7 @@ describe('stringify from defindexes and numbers.', () => {
 			effect: 80,
 			quality: 5,
 			defindex: 139,
-		})
+		});
 
 		assert.equal(itemString, 'Demonflame Modest Pile of Hat');
 	});
@@ -281,7 +329,7 @@ describe('stringify from defindexes and numbers.', () => {
 			quality: 5,
 			elevated: true,
 			defindex: 30928,
-		})
+		});
 
 		assert.equal(itemString, 'Strange Omniscient Orb Balloonihoodie');
 	});
@@ -296,9 +344,12 @@ describe('stringify from defindexes and numbers.', () => {
 			quality: 6,
 			targetDefindex: 133,
 			defindex: 20002,
-		})
+		});
 
-		assert.equal(itemString, 'Non-Craftable Specialized Killstreak Gunboats Kit Fabricator');
+		assert.equal(
+			itemString,
+			'Non-Craftable Specialized Killstreak Gunboats Kit Fabricator'
+		);
 	});
 
 	it('Case #9', () => {
@@ -313,7 +364,7 @@ describe('stringify from defindexes and numbers.', () => {
 			targetDefindex: 828,
 			outputDefindex: 5661,
 			defindex: 20000,
-		})
+		});
 
 		assert.equal(itemString, 'Archimedes Strangifier Chemistry Set');
 	});
@@ -324,7 +375,7 @@ describe('stringify from defindexes and numbers.', () => {
 			craftable: true,
 			quality: 11,
 			defindex: 617,
-		})
+		});
 
 		assert.equal(itemString, 'Strange Backwards Ballcap');
 	});
@@ -338,9 +389,12 @@ describe('stringify from defindexes and numbers.', () => {
 			quality: 6,
 			targetDefindex: 298,
 			defindex: 20003,
-		})
+		});
 
-		assert.equal(itemString, 'Professional Killstreak Iron Curtain Kit Fabricator');
+		assert.equal(
+			itemString,
+			'Professional Killstreak Iron Curtain Kit Fabricator'
+		);
 	});
 
 	it('Case #12', () => {
@@ -350,9 +404,12 @@ describe('stringify from defindexes and numbers.', () => {
 			killstreak: 3,
 			quality: 11,
 			defindex: 1007,
-		})
+		});
 
-		assert.equal(itemString, 'Strange Professional Killstreak Festive Grenade Launcher');
+		assert.equal(
+			itemString,
+			'Strange Professional Killstreak Festive Grenade Launcher'
+		);
 	});
 
 	it('Case #13', () => {
@@ -362,7 +419,7 @@ describe('stringify from defindexes and numbers.', () => {
 			quality: 6,
 			elevated: true,
 			defindex: 201,
-		})
+		});
 
 		assert.equal(itemString, 'Strange Unique Sniper Rifle');
 	});
@@ -373,7 +430,7 @@ describe('stringify from defindexes and numbers.', () => {
 			craftable: true,
 			quality: 6,
 			defindex: 5037,
-		})
+		});
 
 		assert.equal(itemString, 'Australium Gold');
 	});
@@ -384,7 +441,7 @@ describe('stringify from defindexes and numbers.', () => {
 			craftable: true,
 			itemNumber: { type: 'crate', value: 118 },
 			quality: 6,
-		})
+		});
 
 		assert.equal(itemString, 'Blue Moon Case #118');
 	});
@@ -396,7 +453,7 @@ describe('stringify from defindexes and numbers.', () => {
 			quality: 6,
 			isUniqueHat: true,
 			defindex: 30064,
-		})
+		});
 
 		assert.equal(itemString, 'The Tartan Shade');
 	});
@@ -407,7 +464,7 @@ describe('stringify from defindexes and numbers.', () => {
 			craftable: true,
 			quality: 11,
 			defindex: 30986,
-		})
+		});
 
 		assert.equal(itemString, 'Strange Hot Case');
 	});
@@ -418,7 +475,7 @@ describe('stringify from defindexes and numbers.', () => {
 			craftable: true,
 			quality: 11,
 			defindex: 30754,
-		})
+		});
 
 		assert.equal(itemString, 'Strange Hot Heels');
 	});
@@ -429,7 +486,7 @@ describe('stringify from defindexes and numbers.', () => {
 			craftable: true,
 			quality: 11,
 			defindex: 30662,
-		})
+		});
 
 		assert.equal(itemString, 'Strange A Head Full of Hot Air');
 	});
@@ -442,7 +499,7 @@ describe('stringify from defindexes and numbers.', () => {
 			defindex: 9258,
 			target: 'Taunt: Kazotsky Kick',
 			targetDefindex: 1157,
-		})
+		});
 
 		assert.equal(itemString, 'Unusual Taunt: Kazotsky Kick Unusualifier');
 	});
@@ -455,7 +512,7 @@ describe('stringify from defindexes and numbers.', () => {
 			defindex: 5661,
 			target: 'Ghostly Gibus',
 			targetDefindex: 940,
-		})
+		});
 
 		assert.equal(itemString, 'Ghostly Gibus Strangifier');
 	});
@@ -466,110 +523,177 @@ describe('stringify from defindexes and numbers.', () => {
 			craftable: true,
 			quality: 6,
 			defindex: 5633,
-		})
+		});
 
 		assert.equal(itemString, 'Strange Bacon Grease');
 	});
 
 	it('Case #23', () => {
 		const itemString = stringify({
-			"defindex": 30300,
+			defindex: 30300,
 			quality: 13,
 			craftable: true,
 		});
 
 		assert.equal(itemString, 'Haunted Haunted Hat');
-	})
+	});
 
 	it('Case #24 - fixed names', () => {
-		const itemString = stringify({ defindex: 5791, quality: 6, craftable: false });
+		const itemString = stringify({
+			defindex: 5791,
+			quality: 6,
+			craftable: false,
+		});
 
 		assert.equal(itemString, 'Non-Craftable Naughty Winter Crate Key 2014');
 	});
 
 	it('Case #25 - unique hat only defindex', () => {
-		const itemString = stringify({ defindex: 876, quality: 6, craftable: true }, { determineUniqueHat: true });
+		const itemString = stringify(
+			{ defindex: 876, quality: 6, craftable: true },
+			{ determineUniqueHat: true }
+		);
 
 		assert.equal(itemString, 'The K-9 Mane');
 	});
 
 	it('Case #26 - unique hat only defindex off', () => {
-		const itemString = stringify({ defindex: 876, quality: 6, craftable: true }, { determineUniqueHat: false });
+		const itemString = stringify(
+			{ defindex: 876, quality: 6, craftable: true },
+			{ determineUniqueHat: false }
+		);
 
 		assert.equal(itemString, 'K-9 Mane');
 	});
 
 	it('Case #26 - unique hat only defindex with other attributes', () => {
-		const itemString = stringify({ defindex: 876, quality: 6, craftable: false }, { determineUniqueHat: true });
+		const itemString = stringify(
+			{ defindex: 876, quality: 6, craftable: false },
+			{ determineUniqueHat: true }
+		);
 
 		assert.equal(itemString, 'Non-Craftable K-9 Mane');
 	});
 
 	it('Case #26 - unique hat with bad name', () => {
-		const itemString = stringify({ name: 'K-9 Mane', quality: 6, craftable: true }, { determineUniqueHat: true });
+		const itemString = stringify(
+			{ name: 'K-9 Mane', quality: 6, craftable: true },
+			{ determineUniqueHat: true }
+		);
 
 		assert.equal(itemString, 'The K-9 Mane');
 	});
 
 	it('Case #27 - strange unique with determineUniqueHat', () => {
-		const itemString = stringify({ name: 'K-9 Mane', quality: 6, craftable: true, elevated: true }, { determineUniqueHat: true });
+		const itemString = stringify(
+			{ name: 'K-9 Mane', quality: 6, craftable: true, elevated: true },
+			{ determineUniqueHat: true }
+		);
 
 		assert.equal(itemString, 'Strange Unique K-9 Mane');
 	});
 
 	it('Case #27 - craft number with determineUniqueHat', () => {
-		const itemString = stringify({ name: 'Surgeon\'s Stahlhelm', quality: 6, craftable: true, itemNumber: { type: 'craft', value: 1 } }, { determineUniqueHat: true });
+		const itemString = stringify(
+			{
+				name: "Surgeon's Stahlhelm",
+				quality: 6,
+				craftable: true,
+				itemNumber: { type: 'craft', value: 1 },
+			},
+			{ determineUniqueHat: true }
+		);
 
-		assert.equal(itemString, 'The Surgeon\'s Stahlhelm #1');
+		assert.equal(itemString, "The Surgeon's Stahlhelm #1");
 	});
 
 	it('Case #28 - case with determineUniqueHat', () => {
-		const itemString = stringify({ name: 'Gargoyle Case', quality: 6, craftable: true, itemNumber: { type: 'crate', value: 98 } }, { determineUniqueHat: true });
+		const itemString = stringify(
+			{
+				name: 'Gargoyle Case',
+				quality: 6,
+				craftable: true,
+				itemNumber: { type: 'crate', value: 98 },
+			},
+			{ determineUniqueHat: true }
+		);
 
 		assert.equal(itemString, 'Gargoyle Case #98');
 	});
 
 	it('Case #29 - The Bitter Taste of Defeat and Lime with determineUniqueHat', () => {
-		const itemString = stringify({ name: 'The Bitter Taste of Defeat and Lime', quality: 6, craftable: true }, { determineUniqueHat: true });
+		const itemString = stringify(
+			{
+				name: 'The Bitter Taste of Defeat and Lime',
+				quality: 6,
+				craftable: true,
+			},
+			{ determineUniqueHat: true }
+		);
 
 		assert.equal(itemString, 'The Bitter Taste of Defeat and Lime');
-	})
+	});
 
 	it('Case #30 - Normal quality item', () => {
-		const itemString = stringify({ defindex: 211, quality: 0, craftable: true, elevated: true });
+		const itemString = stringify({
+			defindex: 211,
+			quality: 0,
+			craftable: true,
+			elevated: true,
+		});
 
 		assert.equal(itemString, 'Strange Normal Medi Gun');
 	});
 
 	it('Case #31 - Normal quality item #2', () => {
-		const itemString = stringify({ name: 'Medi Gun', quality: 'Normal', craftable: true, elevated: true });
+		const itemString = stringify({
+			name: 'Medi Gun',
+			quality: 'Normal',
+			craftable: true,
+			elevated: true,
+		});
 
 		assert.equal(itemString, 'Strange Normal Medi Gun');
 	});
 
 	it('Case #32 - Red Rock Roscoe texture', () => {
-		const itemString = stringify({ name: 'Pistol', quality: 'Decorated Weapon', craftable: true, wear: 'Field-Tested', festivized: true, killstreak: 'Specialized Killstreak', texture: 0 });
+		const itemString = stringify({
+			name: 'Pistol',
+			quality: 'Decorated Weapon',
+			craftable: true,
+			wear: 'Field-Tested',
+			festivized: true,
+			killstreak: 'Specialized Killstreak',
+			texture: 0,
+		});
 
-		assert.equal(itemString, 'Festivized Specialized Killstreak Red Rock Roscoe Pistol (Field-Tested)');
+		assert.equal(
+			itemString,
+			'Festivized Specialized Killstreak Red Rock Roscoe Pistol (Field-Tested)'
+		);
 	});
 
 	it('Case #33 - Bat', () => {
-		const itemString = stringify({ defindex: 0, quality: 'Unique', craftable: true });
+		const itemString = stringify({
+			defindex: 0,
+			quality: 'Unique',
+			craftable: true,
+		});
 
 		assert.equal(itemString, 'Bat');
-	})
+	});
 
 	it('Case #34 - Bat output', () => {
 		const itemString = stringify({
 			name: 'Chemistry Set',
 			craftable: true,
 			outputDefindex: 0,
-			outputQuality: 'Collector\'s',
-			quality: 'Unique'
+			outputQuality: "Collector's",
+			quality: 'Unique',
 		});
 
-		assert.equal(itemString, 'Collector\'s Bat Chemistry Set');
-	})
+		assert.equal(itemString, "Collector's Bat Chemistry Set");
+	});
 
 	it('Case #34 - Bat target', () => {
 		const itemString = stringify({
@@ -577,11 +701,14 @@ describe('stringify from defindexes and numbers.', () => {
 			craftable: false,
 			killstreak: 'Specialized Killstreak',
 			targetDefindex: 0,
-			quality: 'Unique'
+			quality: 'Unique',
 		});
 
-		assert.equal(itemString, 'Non-Craftable Specialized Killstreak Bat Kit Fabricator');
-	})
+		assert.equal(
+			itemString,
+			'Non-Craftable Specialized Killstreak Bat Kit Fabricator'
+		);
+	});
 
 	it('Case #35 - Unusual Haunted Metal Scrap', () => {
 		const itemString = stringify({
@@ -602,20 +729,35 @@ describe('stringify from defindexes and numbers.', () => {
 			effect: 257,
 		});
 
-		assert.deepEqual(itemString, "Haunted Kraken Rotation Sensation");
+		assert.deepEqual(itemString, 'Haunted Kraken Rotation Sensation');
+	});
+
+	it('Case #47 - Haunted Kraken Rotation Sensation', () => {
+		const itemString = stringify({
+			name: "'Contract Campaigner' War Paint Freelance Grade Keyless Case",
+			craftable: true,
+			quality: 6,
+			defindex: 18004,
+			itemNumber: { type: 'crate', value: 115 },
+		});
+[]
+		assert.deepEqual(itemString, "'Contract Campaigner' War Paint Freelance Grade Keyless Case #115");
 	});
 });
 
-describe("stringify SKU", () => {
-	it("Case #1", () => {
-		const itemString = stringify("5050;6");
+describe('stringify SKU', () => {
+	it('Case #1', () => {
+		const itemString = stringify('5050;6');
 
-		assert.equal(itemString, "Backpack Expander");
+		assert.equal(itemString, 'Backpack Expander');
 	});
 
-	it("Case #2", () => {
-		const itemString = stringify("1071;11;kt-3");
+	it('Case #2', () => {
+		const itemString = stringify('1071;11;kt-3');
 
-		assert.equal(itemString, "Strange Professional Killstreak Golden Frying Pan");
+		assert.equal(
+			itemString,
+			'Strange Professional Killstreak Golden Frying Pan'
+		);
 	});
-})
+});


### PR DESCRIPTION
Fixed items such as "'Contract Campaigner' War Paint Freelance Grade Keyless Case #<!-- -->115" not being parsed with correct attributes.
