### PR TITLE
fix: add newline back to keyless crates due to compability

### DIFF
--- a/src/parseEconItem/ParsedEcon/ItemName.ts
+++ b/src/parseEconItem/ParsedEcon/ItemName.ts
@@ -84,8 +84,6 @@ export default class ItemName {
 			itemNumber,
 		} = this.econ.getNameAttributes('', false, false);
 
-		name = name.replace(/\n/g, ' ');
-
 		if (isUniqueHat) {
 			name = name.replace('The ', '');
 		}

--- a/src/shared/decomposeName.ts
+++ b/src/shared/decomposeName.ts
@@ -28,8 +28,6 @@ export default function (
 	} = attributes;
 	let itemName: string = name;
 
-	itemName = itemName.replace(/\n/g, ' '); // Some items include \n, that is shown as space on steam.
-
 	if (!craftable) itemName = itemName.replace('Non-Craftable ', '');
 	if (australium) itemName = itemName.replace('Australium ', '');
 	if (festivized) itemName = itemName.replace('Festivized ', '');

--- a/src/static/schema.ts
+++ b/src/static/schema.ts
@@ -36,12 +36,12 @@ const DEFINDEXES: { [name: string]: number } = {
 	'Naughty Winter Crate Key 2014': 5791,
 	'Nice Winter Crate Key 2014': 5792,
 
-	"'Decorated War Hero' War Paint Civilian Grade Keyless Case": 18000,
-	"'Decorated War Hero' War Paint Freelance Grade Keyless Case": 18001,
-	"'Decorated War Hero' War Paint Mercenary Grade Keyless Case": 18002,
-	"'Contract Campaigner' War Paint Civilian Grade Keyless Case": 18003,
-	"'Contract Campaigner' War Paint Freelance Grade Keyless Case": 18004,
-	"'Contract Campaigner' War Paint Mercenary Grade Keyless Case": 18005,
+	// "'Decorated War Hero' War Paint Civilian Grade Keyless Case": 18000,
+	// "'Decorated War Hero' War Paint Freelance Grade Keyless Case": 18001,
+	// "'Decorated War Hero' War Paint Mercenary Grade Keyless Case": 18002,
+	// "'Contract Campaigner' War Paint\nCivilian Grade Keyless Case": 18003,
+	// "'Contract Campaigner' War Paint\nFreelance Grade Keyless Case": 18004,
+	// "'Contract Campaigner' War Paint\nMercenary Grade Keyless Case": 18005,
 };
 
 const NAMES: { [defindex: number]: string } = {
@@ -64,12 +64,12 @@ const NAMES: { [defindex: number]: string } = {
 	5792: 'Nice Winter Crate Key 2014',
 	20000: 'Strangifier Chemistry Set',
 	20005: 'Chemistry Set',
-	18000: "'Decorated War Hero' War Paint Civilian Grade Keyless Case",
-	18001: "'Decorated War Hero' War Paint Freelance Grade Keyless Case",
-	18002: "'Decorated War Hero' War Paint Mercenary Grade Keyless Case",
-	18003: "'Contract Campaigner' War Paint Civilian Grade Keyless Case",
-	18004: "'Contract Campaigner' War Paint Freelance Grade Keyless Case",
-	18005: "'Contract Campaigner' War Paint Mercenary Grade Keyless Case",
+	// 18000: "'Decorated War Hero' War Paint\nCivilian Grade Keyless Case",
+	// 18001: "'Decorated War Hero' War Paint\nFreelance Grade Keyless Case",
+	// 18002: "'Decorated War Hero' War Paint\nMercenary Grade Keyless Case",
+	// 18003: "'Contract Campaigner' War Paint\nCivilian Grade Keyless Case",
+	// 18004: "'Contract Campaigner' War Paint\nFreelance Grade Keyless Case",
+	// 18005: "'Contract Campaigner' War Paint\nMercenary Grade Keyless Case",
 };
 
 /* TODO: Set boundaries between these.

--- a/test/econItem.js
+++ b/test/econItem.js
@@ -8341,9 +8341,9 @@ describe('Econ item with true defindex', () => {
 				commodity: true,
 				craftable: true,
 				fullName:
-					"'Contract Campaigner' War Paint Freelance Grade Keyless Case #115",
+					"'Contract Campaigner' War Paint\nFreelance Grade Keyless Case #115",
 				id: undefined,
-				name: "'Contract Campaigner' War Paint Freelance Grade Keyless Case",
+				name: "'Contract Campaigner' War Paint\nFreelance Grade Keyless Case",
 				parts: [],
 				quality: 'Unique',
 				spells: [],

--- a/test/parseString.js
+++ b/test/parseString.js
@@ -611,15 +611,15 @@ describe('parseString', () => {
 		});
 	});
 
-	it("Case #49 -'Contract Campaigner' War Paint Freelance Grade Keyless Case #115", () => {
+	it("Case #49 -'Contract Campaigner' War Paint\nFreelance Grade Keyless Case #115", () => {
 		const itemObject = parseString(
-			"'Contract Campaigner' War Paint Freelance Grade Keyless Case #115",
+			"'Contract Campaigner' War Paint\nFreelance Grade Keyless Case #115",
 			false,
 			false,
 		);
 		
 		assert.deepEqual(itemObject, {
-			name: "'Contract Campaigner' War Paint Freelance Grade Keyless Case",
+			name: "'Contract Campaigner' War Paint\nFreelance Grade Keyless Case",
 			craftable: true,
 			quality: 'Unique',
 			itemNumber: { type: 'crate', value: 115 },
@@ -1295,15 +1295,15 @@ describe('parseString with numbers', () => {
 		});
 	});
 
-		it("Case #49 -'Contract Campaigner' War Paint Freelance Grade Keyless Case #115", () => {
+		it("Case #49 -'Contract Campaigner' War Paint\nFreelance Grade Keyless Case #115", () => {
 		const itemObject = parseString(
-			"'Contract Campaigner' War Paint Freelance Grade Keyless Case #115",
+			"'Contract Campaigner' War Paint\nFreelance Grade Keyless Case #115",
 			true,
 			false,
 		);
 		
 		assert.deepEqual(itemObject, {
-			name: "'Contract Campaigner' War Paint Freelance Grade Keyless Case",
+			name: "'Contract Campaigner' War Paint\nFreelance Grade Keyless Case",
 			craftable: true,
 			quality: 6,
 			itemNumber: { type: 'crate', value: 115 },
@@ -2194,15 +2194,15 @@ describe('parseString with defindexes and numbers.', () => {
 		});
 	});
 
-	it("Case #62 -'Contract Campaigner' War Paint Freelance Grade Keyless Case #115", () => {
+	it("Case #62 -'Contract Campaigner' War Paint\nFreelance Grade Keyless Case #115", () => {
 		const itemObject = parseString(
-			"'Contract Campaigner' War Paint Freelance Grade Keyless Case #115",
+			"'Contract Campaigner' War Paint\nFreelance Grade Keyless Case #115",
 			true,
 			true,
 		);
 		
 		assert.deepEqual(itemObject, {
-			name: "'Contract Campaigner' War Paint Freelance Grade Keyless Case",
+			name: "'Contract Campaigner' War Paint\nFreelance Grade Keyless Case",
 			craftable: true,
 			quality: 6,	
 			defindex: 18004,

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -734,7 +734,7 @@ describe('stringify from defindexes and numbers.', () => {
 
 	it('Case #47 - Haunted Kraken Rotation Sensation', () => {
 		const itemString = stringify({
-			name: "'Contract Campaigner' War Paint Freelance Grade Keyless Case",
+			name: "'Contract Campaigner' War Paint\nFreelance Grade Keyless Case",
 			craftable: true,
 			quality: 6,
 			defindex: 18004,
@@ -743,7 +743,7 @@ describe('stringify from defindexes and numbers.', () => {
 
 		assert.deepEqual(
 			itemString,
-			"'Contract Campaigner' War Paint Freelance Grade Keyless Case #115"
+			"'Contract Campaigner' War Paint\nFreelance Grade Keyless Case #115"
 		);
 	});
 });


### PR DESCRIPTION
Add newline back to keyless crates due to compatibility. I misinterpreted the way backpack.tf and steam process these items and removed it, while it actually needs to stay in the name.