### PR TITLE
fix: Treasure Trove effect being for hat and taunt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "tf2-item-format",
       "version": "5.9.11",
       "license": "MIT",
+      "dependencies": {
+        "tf2-static-schema": "^1.68.0"
+      },
       "devDependencies": {
         "@semantic-release/git": "^10.0.1",
         "chai": "^4.2.0",
@@ -23,7 +26,7 @@
         "node": ">=12.7.0"
       },
       "optionalDependencies": {
-        "tf2-static-schema": "^1.63.0"
+        "tf2-static-schema": "^1.68.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -10829,9 +10832,10 @@
       "dev": true
     },
     "node_modules/tf2-static-schema": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/tf2-static-schema/-/tf2-static-schema-1.67.0.tgz",
-      "integrity": "sha512-c6K+khNnTi2axnfWJnGgtoR/M9DqX51YCnJ9MgcHwFrMBmh0pxt2+uq2sMPhetM+FvNwAp+iMIc7JfIwPOFXFQ==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/tf2-static-schema/-/tf2-static-schema-1.68.0.tgz",
+      "integrity": "sha512-3w7HPS1rFar1dV5ILm5U4b7jq8v6k51bGt0134h5DcWBPR36UkOebqF7BqZvJxjdj6E2DYLxSbGL9QQKvIwDkw==",
+      "license": "MIT",
       "optional": true,
       "optionalDependencies": {
         "axios": "^1.6.0",
@@ -19125,9 +19129,9 @@
       "dev": true
     },
     "tf2-static-schema": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/tf2-static-schema/-/tf2-static-schema-1.67.0.tgz",
-      "integrity": "sha512-c6K+khNnTi2axnfWJnGgtoR/M9DqX51YCnJ9MgcHwFrMBmh0pxt2+uq2sMPhetM+FvNwAp+iMIc7JfIwPOFXFQ==",
+      "version": "1.68.0",
+      "resolved": "https://registry.npmjs.org/tf2-static-schema/-/tf2-static-schema-1.68.0.tgz",
+      "integrity": "sha512-3w7HPS1rFar1dV5ILm5U4b7jq8v6k51bGt0134h5DcWBPR36UkOebqF7BqZvJxjdj6E2DYLxSbGL9QQKvIwDkw==",
       "optional": true,
       "requires": {
         "axios": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/danocmx/node-tf2-item-format#readme",
   "optionalDependencies": {
-    "tf2-static-schema": "^1.63.0"
+    "tf2-static-schema": "^1.68.0"
   },
   "devDependencies": {
     "@semantic-release/git": "^10.0.1",

--- a/src/createBPListing.ts
+++ b/src/createBPListing.ts
@@ -10,6 +10,7 @@ import {
 	StrigifySKUAttributes,
 } from './types';
 import { ISchema } from './types/schema';
+import isTaunt from './util/isTaunt';
 
 const DEFAULT_OPTIONS: CreateBPListingOptions = {
 	unuSkinsToDecorated: true,
@@ -131,7 +132,14 @@ function getPriceindex(
 			(item.output && schema.getDefindex(item.output));
 	}
 
-	if (item.effect) return schema.getEffectEnum(item.effect);
+	if (item.effect) {
+		if (item.effect == "Treasure Trove") {
+			if (isTaunt(name)) return 3165;
+			else return 289;
+		}
+
+		return schema.getEffectEnum(item.effect);
+	}
 	if (item.itemNumber && isCrate(item.itemNumber))
 		return (item.itemNumber as ItemNumber).value;
 	if (isUnusualfierOrStrangifier(name)) return targetDefindex as number;

--- a/src/parseEconItem/ParsedEcon.ts
+++ b/src/parseEconItem/ParsedEcon.ts
@@ -157,6 +157,7 @@ export default class ParsedEcon {
 		if (inNumbers) {
 			const convertedAttributes = getConvertedIntAttributes(
 				this.schema,
+				name,
 				attrs
 			);
 

--- a/src/parseString.ts
+++ b/src/parseString.ts
@@ -61,7 +61,7 @@ function parseString(
 	};
 
 	if (inNumbers) {
-		const convertedAttributes = getConvertedIntAttributes(schema, {
+		const convertedAttributes = getConvertedIntAttributes(schema, itemName, {
 			killstreak: attributes.killstreak,
 			wear: attributes.wear,
 			effect: attributes.effect,

--- a/src/shared/getConvertedIntAttributes.ts
+++ b/src/shared/getConvertedIntAttributes.ts
@@ -2,9 +2,11 @@ import { hasDefindex } from './guards';
 
 import { ConvertableAttributes } from '../types';
 import { ISchema } from '../types/schema';
+import isTaunt from '../util/isTaunt';
 
 export default function (
 	schema: ISchema,
+	name: string,
 	item: ConvertableAttributes
 ): {
 	killstreak?: number;
@@ -14,12 +16,22 @@ export default function (
 	outputQuality?: number;
 	texture?: number;
 } {
+	let effect: number | undefined;
+	if (item.effect) {
+		if (item.effect == "Treasure Trove") {
+			if (isTaunt(name)) effect = 3165;
+			else effect = 289;
+		} else {
+			effect = schema.getEffectEnum(item.effect);
+		}
+	}
+
 	return {
+		effect,
 		killstreak: item.killstreak
 			? schema.getKillstreakEnum(item.killstreak)
 			: undefined,
 		wear: item.wear ? schema.getWearEnum(item.wear) : undefined,
-		effect: item.effect ? schema.getEffectEnum(item.effect) : undefined,
 		quality: schema.getQualityEnum(item.quality),
 		outputQuality: item.outputQuality
 			? schema.getQualityEnum(item.outputQuality)

--- a/src/util/isTaunt.ts
+++ b/src/util/isTaunt.ts
@@ -1,0 +1,3 @@
+export default function isTaunt(item: string): boolean {
+	return item.startsWith('Taunt: ') || item == 'Shred Alert';
+}

--- a/test/createBPListing.js
+++ b/test/createBPListing.js
@@ -349,4 +349,36 @@ describe('createBPListing', () => {
 			priceindex: 0,
 		});
 	});
+
+	it('Case #21 - Treasure Trove taunt', () => {
+		const listing = createBPListing({
+			name: "Taunt: The High Five!",
+			effect: "Treasure Trove",
+			quality: 5,
+			craftable: true,
+		});
+
+		assert.deepEqual(listing, {
+			quality: 5,
+			craftable: 1,
+			item_name: 'Taunt: The High Five!',
+			priceindex: 3165,
+		});
+	});
+
+	it('Case #22 - Treasure Trove hat', () => {
+		const listing = createBPListing({
+			name: "Class Crown",
+			effect: "Treasure Trove",
+			quality: 5,
+			craftable: true,
+		});
+
+		assert.deepEqual(listing, {
+			quality: 5,
+			craftable: 1,
+			item_name: 'Class Crown',
+			priceindex: 289,
+		});
+	});
 });

--- a/test/parseString.js
+++ b/test/parseString.js
@@ -1295,7 +1295,7 @@ describe('parseString with numbers', () => {
 		});
 	});
 
-		it("Case #49 -'Contract Campaigner' War Paint Freelance Grade Keyless Case #115", () => {
+	it("Case #49 -'Contract Campaigner' War Paint Freelance Grade Keyless Case #115", () => {
 		const itemObject = parseString(
 			"'Contract Campaigner' War Paint Freelance Grade Keyless Case #115",
 			true,
@@ -1307,6 +1307,36 @@ describe('parseString with numbers', () => {
 			craftable: true,
 			quality: 6,
 			itemNumber: { type: 'crate', value: 115 },
+		});
+	});
+
+	it("Case #50 - Treasure Trove taunt", () => {
+		const itemObject = parseString(
+			"Treasure Trove Shred Alert",
+			true,
+			false,
+		);
+		
+		assert.deepEqual(itemObject, {
+			name: "Shred Alert",
+			craftable: true,
+			quality: 5,
+			effect: 3165
+		});
+	});
+
+	it("Case #50 - Treasure Trove hat", () => {
+		const itemObject = parseString(
+			"Treasure Trove Class Crown",
+			true,
+			false,
+		);
+		
+		assert.deepEqual(itemObject, {
+			name: "Class Crown",
+			craftable: true,
+			quality: 5,
+			effect: 289
 		});
 	});
 });
@@ -2207,6 +2237,38 @@ describe('parseString with defindexes and numbers.', () => {
 			quality: 6,	
 			defindex: 18004,
 			itemNumber: { type: 'crate', value: 115 },
+		});
+	});
+
+	it("Case #63 - Treasure Trove taunt", () => {
+		const itemObject = parseString(
+			"Treasure Trove Shred Alert",
+			true,
+			true,
+		);
+		
+		assert.deepEqual(itemObject, {
+			name: "Shred Alert",
+			craftable: true,
+			quality: 5,
+			effect: 3165,
+			defindex: 1015
+		});
+	});
+
+	it("Case #64 - Treasure Trove hat", () => {
+		const itemObject = parseString(
+			"Treasure Trove Class Crown",
+			true,
+			true,
+		);
+		
+		assert.deepEqual(itemObject, {
+			name: "Class Crown",
+			craftable: true,
+			quality: 5,
+			effect: 289,
+			defindex: 30808 
 		});
 	});
 });


### PR DESCRIPTION
Resolve an issue where Treasure Trove effect from the new Summer 2024 case can occur on both taunt and hat, with same name but different back enumeration, a work-around had to be added to mitigate this issue.