### PR TITLE
fix: properly handle strange haunted

### DIFF
--- a/src/parseEconItem/ParsedEcon/getPropertyAttributes/getElevated.ts
+++ b/src/parseEconItem/ParsedEcon/getPropertyAttributes/getElevated.ts
@@ -5,7 +5,7 @@ export default function (item: EconItem, tags: TagAttributes): boolean {
 }
 
 function isStrangeType({ type }: EconItem): boolean {
-	return /( - Kills: |- Points Scored: )\d+/.test(type);
+	return /( - Kills: |- Points Scored: |- Carnival Kills: )\d+/.test(type);
 }
 
 function isStrangeQuality({ quality }: TagAttributes): boolean {


### PR DESCRIPTION
It does not properly handle strange haunted because of this check: https://github.com/danocmx/node-tf2-item-format/blob/25c75b433d7d37d0112c75bb3f035dbfebe1bb04/src/parseEconItem/ParsedEcon/getPropertyAttributes/getElevated.ts#L8

I used the item below to test with. It is now a banned account for some reason so I can't get the item from the inventory again.

```json
{
   "appid":440,
   "contextid":"2",
   "assetid":"14989669141",
   "classid":"1347837560",
   "instanceid":"629236864",
   "amount":1,
   "pos":20,
   "id":"14989669141",
   "currency":0,
   "background_color":"3C352E",
   "icon_url":"fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEYalZFYhbnvDFAt8DzA_aHB_AGpNY095dQl2Y9wlQpN7LsaDRmdlySVaZbC_Rs9Q67W3VlupRiAIDjpOlUewnsstbYc-57boTWkMU",
   "icon_url_large":"fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEYalZFYhbnvDFAt8DzA_aHB_AGpNY095dQl2Y9wlQpN7LsaDRmdlySVaZbC_Rs9Q67W3VlupRiAIDjpOlUewnsstbYc-57boTWkMU",
   "descriptions":[
      {
         "value":"(Carnival Underworld Kills: 0)",
         "color":"756b5e"
      },
      {
         "value":"(Carnival Games Won: 0)",
         "color":"756b5e"
      },
      {
         "value":"Holiday Restriction: Halloween / Full Moon",
         "color":"756b5e"
      },
      {
         "type":"usertext",
         "value":"''Please don't kill me with fire''"
      },
      {
         "value":" "
      },
      {
         "value":"Canis Ex Machina",
         "color":"e1e10f"
      },
      {
         "value":" "
      },
      {
         "value":"The Hundkopf",
         "color":"8b8989"
      },
      {
         "value":"The Herzensbrecher",
         "color":"8b8989"
      },
      {
         "value":"The Kriegsmaschine-9000",
         "color":"8b8989"
      }
   ],
   "tradable":true,
   "actions":[
      {
         "link":"http://wiki.teamfortress.com/scripts/itemredirect.php?id=30487&lang=en_US",
         "name":"Item Wiki Page..."
      },
      {
         "link":"steam://rungame/440/76561202255233023/+tf_econ_item_preview%20S%owner_steamid%A%assetid%D10365507332028992507",
         "name":"Inspect in Game..."
      }
   ],
   "fraudwarnings":[
      "This item has been renamed.\nOriginal name: \"Hundkopf\""
   ],
   "name":"''K9 Kranium''",
   "name_color":"38f3ab",
   "type":"Strange Cosmetic Item - Carnival Kills: 0",
   "market_name":"Strange Haunted Hundkopf",
   "market_hash_name":"Strange Haunted Hundkopf",
   "market_actions":[
      {
         "link":"steam://rungame/440/76561202255233023/+tf_econ_item_preview%20M%listingid%A%assetid%D10365507332028992507",
         "name":"Inspect in Game..."
      }
   ],
   "commodity":false,
   "market_tradable_restriction":7,
   "market_marketable_restriction":0,
   "marketable":true,
   "tags":[
      {
         "internal_name":"haunted",
         "name":"Haunted",
         "category":"Quality",
         "color":"38f3ab",
         "category_name":"Quality"
      },
      {
         "internal_name":"misc",
         "name":"Cosmetic",
         "category":"Type",
         "color":"",
         "category_name":"Type"
      },
      {
         "internal_name":"Medic",
         "name":"Medic",
         "category":"Class",
         "color":"",
         "category_name":"Class"
      }
   ],
   "is_currency":false
}
```

Returns this:

```json
{
   "name":"Strange Hundkopf",
   "fullName":"Strange Haunted Hundkopf",
   "id":"14989669141",
   "img":"https://steamcommunity-a.akamaihd.net/economy/image/fWFc82js0fmoRAP-qOIPu5THSWqfSmTELLqcUywGkijVjZULUrsm1j-9xgEYalZFYhbnvDFAt8DzA_aHB_AGpNY095dQl2Y9wlQpN7LsaDRmdlySVaZbC_Rs9Q67W3VlupRiAIDjpOlUewnsstbYc-57boTWkMU/",
   "tradable":true,
   "craftable":true,
   "quality":"Haunted",
   "level":-1,
   "classes":[
      "Medic"
   ],
   "type":"misc",
   "parts":[
      "Carnival Underworld Kills",
      "Carnival Games Won"
   ],
   "spells":[
      
   ],
   "marketable":true,
   "commodity":false
}
```

If I change the type to "Strange Cosmetic Item - Carnival Kills: 0" it will become elevated.

I would change it to something more generic, such as checking for "Strange x - x: y" where x is any characters and y is a number but I figured the fix I made was simpler.